### PR TITLE
Fix Update README job: supply base for create-pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
             - After each release, I will update the version in the installation section.
             - After any changes to the "docs/index.md" file, I will update the README.md file accordingly.
         branch: zio-sbt-website/update-readme
+        base: ${{ github.event.repository.default_branch }}
         commit-message: Update README.md
         token: ${{ steps.generate-token.outputs.token }}
         delete-branch: true

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import zio.json.ast.Json
 import zio.sbt.ZioSbtCiPlugin._
 import zio.sbt.githubactions.{Job, Step, Strategy}
 
@@ -67,7 +68,22 @@ inThisBuild(
           )
         )
       )
-    )
+    ),
+    // Works around a bug shared with zio-sbt's own release workflow (e.g. zio/zio-sbt#v0.6.3):
+    // a `release`-triggered run checks out the tag, so HEAD is detached, and
+    // `peter-evans/create-pull-request` then requires an explicit `base` to know which branch to
+    // target — the plugin's default step doesn't set one.
+    ciUpdateReadmeJobs := updateReadmeJobs.value.map { job =>
+      job.copy(steps = job.steps.map {
+        case s: Step.SingleStep if s.name == "Create Pull Request" =>
+          s.copy(parameters =
+            s.parameters + ("base" -> Json.Str(
+              "${{ github.event.repository.default_branch }}"
+            ))
+          )
+        case other => other
+      })
+    }
   )
 )
 


### PR DESCRIPTION
## Summary

The `Update README` job has been failing on every release here — see e.g. https://github.com/zio/zio-constraintless/actions/runs/31173713880/job/92850966642:

```
##[error]When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.
```

Root cause: the job runs on `release: published`, and that checks out the release **tag**, leaving HEAD detached. `peter-evans/create-pull-request@v8` can't infer a target branch from a detached HEAD and requires an explicit `base` — which `zio-sbt-ci`'s default `updateReadmeJobs` step doesn't set.

This isn't specific to this repo: `zio/zio-sbt`'s own last three releases (v0.6.1, v0.6.2, v0.6.3) hit the exact same failure in their own `Update README` job, starting right when their generated workflow's `actions/checkout` bumped v6 → v7. So it's a real, currently-live gap in the plugin's default job — not something misconfigured on our end.

## Fix

Override `ciUpdateReadmeJobs` in `build.sbt` to inject `base: ${{ github.event.repository.default_branch }}` into the generated `Create Pull Request` step, reusing the plugin's default job/steps rather than hand-rolling them.

I'll also report/fix this upstream in `zio/zio-sbt` so every adopter gets it without a local workaround; this PR is the immediate fix for this repo in the meantime.

## Test plan
- [x] `sbt scalafmtAll` / `sbt "all scalafmtSbt"`
- [x] `sbt "++2.13; check"` passes
- [x] `sbt ciCheckGithubWorkflow` passes — committed `ci.yml` matches generated output, and now includes `base: ${{ github.event.repository.default_branch }}` on the Create Pull Request step
- [ ] Confirm on the next release that `Update README` succeeds